### PR TITLE
Update Config.php

### DIFF
--- a/Service/Config.php
+++ b/Service/Config.php
@@ -48,7 +48,7 @@ class Config implements ConfigInterface
      * @param int|null $storeId
      * @return string|null
      */
-    public function getSearchspringSiteId(int $storeId = null): ?string
+    public function getSearchspringSiteId(?int $storeId = null): ?string
     {
         return (string)$this->scopeConfig->getValue(
             self::SEARCHSPRING_SITE_ID,


### PR DESCRIPTION
Suggesting as I see the following error on bin/magento se:di:compile 

```
Deprecated Functionality: Searchspring\Tracking\Service\Config::getSearchspringSiteId(): Implicitly marking parameter $s
  toreId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/searchspring/m
  agento2-searchspring-tracking/Service/Config.php on line 51
```

I am working on an a 2.4.8-p5 upgrade, which includes a php 8.4 upgrade as well. 
